### PR TITLE
CAP-20 : added swagger deps and config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,5 @@ spring.jpa.hibernate.ddl-auto=update
 
 server.error.include-message=always
 server.error.include-stacktrace=always
+
+springdoc.swagger-ui.path=/docs


### PR DESCRIPTION
#### In your browser, go to http://localhost:8080/docs you will see docs (when controllers are added obviously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an interactive API documentation UI (OpenAPI/Swagger) accessible at /docs.
  - Users can browse available endpoints, view request/response models, and test calls directly from the browser.

- Chores
  - Updated build configuration to include support for the API documentation UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->